### PR TITLE
When no CRL file is defined, CRL check should be disabled completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ of Erlang property list.
 | `cacertfile_path`    | `/opt/ca/ca.crt.pem`               | SSLCACertificateFile  | Where is the client root CA located. Can be inside apps/epp_proxy/priv or absolute path.
 | `certfile_path`      | `/opt/ca/server.crt.pem`           | SSLCertificateFile    | Where is the server certificate located. Can be inside apps/epp_proxy/priv or absolute path.
 | `keyfile_path`       | `/opt/ca/server.key.pem`           | SSLCertificateKeyFile | Where is the server key located. Can be inside apps/epp_proxy/priv or absolute path.
-| `crlfile_path`       | `/opt/ca/crl.pem`                  | SSLCARevocationFile   | Where is the CRL file located. Can be inside apps/epp_proxy/priv or absolute path.
+| `crlfile_path`       | `/opt/ca/crl.pem`                  | SSLCARevocationFile   | Where is the CRL file located. Can be inside apps/epp_proxy/priv or absolute path. When not set, not CRL check is performed.
 
 
 Migrating from mod_epp

--- a/config/docker.config
+++ b/config/docker.config
@@ -10,7 +10,8 @@
                {cacertfile_path, "/opt/ca/certs/ca.crt.pem"},
                {certfile_path, "/opt/ca/certs/apache.crt"},
                {keyfile_path, "/opt/ca/private/apache.key"},
-               {crlfile_path, "/opt/ca/crl/crl.pem"}]},
+               {crlfile_path, "/opt/ca/crl/crl.pem"}
+	       ]},
   {lager, [
     {handlers, [
                {lager_console_backend, [{level, debug}]}

--- a/config/sys.config
+++ b/config/sys.config
@@ -24,7 +24,7 @@
                %% Path to server's key file.
                {keyfile_path, "/opt/shared/ca/certs/key.pem"},
 
-               %% Path to CRL file.
+               %% Path to CRL file. When this option is undefined, no CRL check is performed.
                {crlfile_path, "/opt/shared/ca/certs/key.pem"}]},
   {lager, [
     {handlers, [


### PR DESCRIPTION
Fixes #20 