### PR TITLE
Handle hello that is not nested under command element

### DIFF
--- a/apps/epp_proxy/src/epp_xml.erl
+++ b/apps/epp_proxy/src/epp_xml.erl
@@ -7,13 +7,21 @@
 %% Get command from an xmlElement. Otherwise return undefined.
 get_command(Record)
     when is_record(Record, xmlElement) ->
+    case xmerl_xpath:string("name(/epp/*[1])", Record) of
+      {xmlObj, string, "hello"} -> "hello";
+      {xmlObj, string, "command"} -> get_command1(Record);
+      {xmlObj, string, []} -> undefined
+    end;
+get_command(_) -> undefined.
+
+get_command1(Record)
+    when is_record(Record, xmlElement) ->
     case xmerl_xpath:string("name(/epp/command/*[1])",
 			    Record)
 	of
       {xmlObj, string, []} -> undefined;
       {xmlObj, string, Command} -> Command
-    end;
-get_command(_) -> undefined.
+    end.
 
 %% xml_erl expects a list of characters, so let's give it to it.
 %% Otherwise return an error tuple.

--- a/apps/epp_proxy/test/tcp_client_SUITE.erl
+++ b/apps/epp_proxy/test/tcp_client_SUITE.erl
@@ -8,6 +8,7 @@
 -export([frame_size_test_case/1,
          greetings_test_case/1,
          session_test_case/1,
+         simple_hello_test_case/1,
          valid_command_test_case/1,
          long_message_test_case/1,
          invalid_command_test_case/1,
@@ -18,6 +19,7 @@ all() ->
     [frame_size_test_case,
      greetings_test_case,
      session_test_case,
+     simple_hello_test_case,
      valid_command_test_case,
      long_message_test_case,
      invalid_command_test_case,
@@ -49,6 +51,17 @@ greetings_test_case(Config) ->
     {ok, Socket} = gen_tcp:connect("localhost", 1180, Options, 2000),
     Data = receive_data(Socket),
     match_data(Data, "<greeting>"),
+    ok.
+
+simple_hello_test_case(Config) ->
+    Options = proplists:get_value(tcp_options, Config),
+    {ok, Socket} = gen_tcp:connect("localhost", 1180, Options, 2000),
+    _Data = receive_data(Socket),
+    ok = send_data(hello_command(), Socket),
+    HelloResponse = receive_data(Socket),
+    match_data(HelloResponse,
+               "<extURI>urn:ietf:params:xml:ns:secDNS-1.1</extURI>"),
+    match_data(HelloResponse, "https://epp.tld.ee/schema/eis-1.0.xsd"),
     ok.
 
 session_test_case(Config) ->
@@ -211,6 +224,12 @@ receive_data(Socket) ->
 match_data(Data, Pattern) ->
     {ok, MatchPattern} = re:compile(Pattern),
     {match, _Captured} = re:run(Data, MatchPattern).
+
+hello_command() ->
+    <<"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>",
+      "<epp xmlns=\"https://epp.tld.ee/schema/epp-ee-1.0.xsd\">",
+      "<hello/>",
+      "</epp>">>.
 
 login_command() ->
     <<"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"


### PR DESCRIPTION
This should fix #25 while retaining the current nesting behaviour in case someone uses it.