### PR TITLE
Replace xmerl with erlsom

### DIFF
--- a/apps/epp_proxy/test/epp_util_SUITE.erl
+++ b/apps/epp_proxy/test/epp_util_SUITE.erl
@@ -74,6 +74,5 @@ readable_ip_test_case(_Config) ->
 path_for_file_test_case(_Config) ->
     AbsoluteFilename = "/usr/bin",
     AbsoluteFilename = epp_util:path_for_file(AbsoluteFilename),
-    RelativeFilename = "usr/bin",
     true = (AbsoluteFilename =:= epp_util:path_for_file(AbsoluteFilename)),
     ok.

--- a/apps/epp_proxy/test/epp_xml_SUITE.erl
+++ b/apps/epp_proxy/test/epp_xml_SUITE.erl
@@ -1,9 +1,7 @@
 -module(epp_xml_SUITE).
 
 -include_lib("common_test/include/ct.hrl").
-
-%% This is required for parse tests.
--include_lib("xmerl/include/xmerl.hrl").
+-include_lib("stdlib/include/assert.hrl").
 
 -define(sampleCommandList,
         "<epp>
@@ -59,24 +57,28 @@ parse_not_a_list_or_binary_test_case(_Config) ->
 
 parse_sample_valid_xml_list_test_case(_Config) ->
     Input = ?sampleCommandList,
-    {ok, Record} = epp_xml:parse(Input),
-    true = is_record(Record, xmlElement),
+    {ok, Result} = epp_xml:parse(Input),
+    ?assertEqual(["epp", "command", "login", "clID", "pw", "clTRID"],
+                 Result),
     ok.
 
 parse_sample_valid_xml_binary_test_case(_Config) ->
     Input = list_to_binary(?sampleCommandList),
-    {ok, Record} = epp_xml:parse(Input),
-    true = is_record(Record, xmlElement),
+    {ok, Result} = epp_xml:parse(Input),
+    ?assertEqual(["epp", "command", "login", "clID", "pw", "clTRID"],
+                 Result),
     ok.
 
 parse_sample_invalid_xml_list_test_case(_Config) ->
     Input = "Some text",
-    {error, {fatal, _Details}} = epp_xml:parse(Input),
+    ExpectedResult = {error, "Malformed: Illegal character in prolog"},
+    ?assertEqual(ExpectedResult, epp_xml:parse(Input)),
     ok.
 
 parse_sample_invalid_xml_binary_test_case(_Config) ->
-    Input = list_to_binary("Some text"),
-    {error, {fatal, _Details}} = epp_xml:parse(Input),
+    Input = <<"</epp>\n">>,
+    ExpectedResult = {error, {badmatch, []}},
+    ?assertEqual(ExpectedResult, epp_xml:parse(Input)),
     ok.
 
 %% find_cltrid

--- a/config/docker.config
+++ b/config/docker.config
@@ -1,3 +1,4 @@
+%% -*- erlang -*-
 [
   {epp_proxy, [
                {dev_mode, true},

--- a/config/sys.config
+++ b/config/sys.config
@@ -1,3 +1,4 @@
+%% -*- erlang -*-
 [
   {epp_proxy, [
                %% Enables or disable TCP connections without TLS (true/false)
@@ -9,7 +10,7 @@
                {tls_port, 700},
 	       %% When set to true, you can connect to EPP over HTTPS endpoints without
 	       %% verifying their TLS certificates.
-	       {insecure, false}
+	       {insecure, false},
                %% URL of EPP endpoints. Can be pointed at a web server (Apache/NGINX)
                %% Can contain port (https://some-host:3000/epp/session)
                %% Honors the prepended protocol (http / https).

--- a/config/test.config
+++ b/config/test.config
@@ -1,3 +1,4 @@
+%% -*- erlang -*-
 [
   {epp_proxy, [{dev_mode, true},
                {tcp_port, 1180},

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,8 @@
 {deps, [{hackney, "1.15.1"},
         {syslog, {git, "https://github.com/Vagabond/erlang-syslog.git", {branch, "master"}}},
         {lager, "3.7.0"},
-        {lager_syslog, {git, "https://github.com/erlang-lager/lager_syslog.git"}}]}.
+        {lager_syslog, {git, "https://github.com/erlang-lager/lager_syslog.git"}},
+        {erlsom, "1.5.0"}]}.
 
 {relx, [{release, {epp_proxy, "git"},
          [epp_proxy,
@@ -11,7 +12,7 @@
           lager_syslog,
           hackney,
           sasl,
-          xmerl]},
+          erlsom]},
 
         {sys_config, "./config/sys.config"},
         {dev_mode, false},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,5 +1,6 @@
 {"1.1.0",
 [{<<"certifi">>,{pkg,<<"certifi">>,<<"2.5.1">>},1},
+ {<<"erlsom">>,{pkg,<<"erlsom">>,<<"1.5.0">>},0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"hackney">>,{pkg,<<"hackney">>,<<"1.15.1">>},0},
  {<<"idna">>,{pkg,<<"idna">>,<<"6.0.0">>},1},
@@ -20,6 +21,7 @@
 [
 {pkg_hash,[
  {<<"certifi">>, <<"867CE347F7C7D78563450A18A6A28A8090331E77FA02380B4A21962A65D36EE5">>},
+ {<<"erlsom">>, <<"C5A5CDD0EE0E8DCA62BCC4B13FF08DA24FDEFC16CCD8B25282A2FDA2BA1BE24A">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
  {<<"hackney">>, <<"9F8F471C844B8CE395F7B6D8398139E26DDCA9EBC171A8B91342EE15A19963F4">>},
  {<<"idna">>, <<"689C46CBCDF3524C44D5F3DDE8001F364CD7608A99556D8FBD8239A5798D4C10">>},


### PR DESCRIPTION
Relates to #30.

Should remove possible memory leak from xmerl. If that is not the reason for the application being killed, then I'd need more data about where exactly memory is used.

Also includes small syntax fixes to `sys.config`, as well as one compilation warning removal.

For all intents and purposes: this is only tested by hand, so needs some test runs on staging, as I possibly cannot generate enough data myself.